### PR TITLE
feat(isr): enable ISR for post and page routes

### DIFF
--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -55,17 +55,17 @@ export async function getStaticPaths() {
     paths: pages.map((page) => ({
       params: { slug: page.slug }
     })),
-    fallback: false
+    fallback: 'blocking'
   }
 }
 
-export async function getStaticProps({ 
-  params 
-}: { 
-  params: { slug: string } 
+export async function getStaticProps({
+  params
+}: {
+  params: { slug: string }
 }) {
   const page = getPage(params.slug)
-  
+
   if (!page) {
     return {
       notFound: true
@@ -73,6 +73,7 @@ export async function getStaticProps({
   }
 
   return {
-    props: { page }
+    props: { page },
+    revalidate: 3600
   }
 }

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -315,12 +315,12 @@ export async function getStaticPaths() {
     paths: posts.map((post) => ({
       params: { slug: post.slug }
     })),
-    fallback: false
+    fallback: 'blocking'
   }
 }
 
-export async function getStaticProps({ 
-  params 
+export async function getStaticProps({
+  params
 }: {
   params: { slug: string }
 }) {
@@ -331,6 +331,7 @@ export async function getStaticProps({
     }
   }
   return {
-    props: { post }
+    props: { post },
+    revalidate: 3600
   }
 }


### PR DESCRIPTION
## Summary
- Change `fallback: false` → `fallback: 'blocking'` in `posts/[slug].tsx` and `[slug].tsx`
- Add `revalidate: 3600` so pages auto-refresh hourly without a full rebuild
- New posts/pages now appear within 1 hour instead of requiring a redeploy

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Deploy to Vercel and verify a new post appears without rebuilding

Closes #12