### PR TITLE
fix(api): GET-only guard and 10 MB size limit on content route

### DIFF
--- a/src/pages/api/__tests__/content.test.ts
+++ b/src/pages/api/__tests__/content.test.ts
@@ -86,4 +86,24 @@ describe('GET /api/content/[...path]', () => {
     expect(res._getStatusCode()).toBe(200)
     expect(res.getHeader('Content-Type')).toBe('image/png')
   })
+
+  it('returns 405 for non-GET requests', async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: 'POST',
+      query: { path: ['images', 'photo.png'] },
+    })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(405)
+  })
+
+  it('returns 413 when file exceeds 10 MB', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true, size: 11 * 1024 * 1024 })
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: 'GET',
+      query: { path: ['images', 'huge.png'] },
+    })
+    await handler(req, res)
+    expect(res._getStatusCode()).toBe(413)
+  })
 })

--- a/src/pages/api/content/[...path].ts
+++ b/src/pages/api/content/[...path].ts
@@ -23,7 +23,15 @@ function getContentType(filePath: string) {
   return contentTypeByExtension[extension] || 'application/octet-stream';
 }
 
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    res.status(405).end('Method Not Allowed')
+    return
+  }
+
   const pathParts = req.query.path;
   const segments = Array.isArray(pathParts) ? pathParts : pathParts ? [pathParts] : [];
 
@@ -51,6 +59,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const stat = await fs.stat(resolvedPath);
     if (!stat.isFile()) {
       res.status(404).end('Not found');
+      return;
+    }
+
+    if (stat.size > MAX_FILE_SIZE) {
+      res.status(413).end('File too large');
       return;
     }
 


### PR DESCRIPTION
Closes #18